### PR TITLE
fix firebase versioning

### DIFF
--- a/.github/workflows/cd_deploy_to_firebase_distribution.yml
+++ b/.github/workflows/cd_deploy_to_firebase_distribution.yml
@@ -14,6 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
 
       - name: Setup JDK 17
         uses: actions/setup-java@v4
@@ -45,8 +49,13 @@ jobs:
           cp keys.properties ./data/remote_data_source/search/keys.properties
 
 
+      - name: Compute version for this run
+        run: |
+          echo "CI_VERSION_CODE=${{ github.run_number }}" >> "$GITHUB_ENV"
+          echo "CI_VERSION_NAME=1.0.${{ github.run_number }}" >> "$GITHUB_ENV"
+
       - name: Build signed APK
-        run: ./gradlew assembleRelease
+        run: ./gradlew assembleRelease --no-daemon
 
       - name: Show available build-tools
         run: ls /usr/local/lib/android/sdk/build-tools/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,9 +18,13 @@ android {
         applicationId = libs.versions.applicationId.get()
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = libs.versions.versionCode.get().toInt()
-        versionName = libs.versions.versionName.get()
         testInstrumentationRunner = libs.versions.testRunner.get()
+
+        val ciCode = System.getenv("CI_VERSION_CODE")?.toIntOrNull()
+        val ciName = System.getenv("CI_VERSION_NAME")
+
+        versionCode = ciCode ?: libs.versions.versionCode.get().toInt()
+        versionName = ciName ?: libs.versions.versionName.get()
     }
 
     buildTypes {


### PR DESCRIPTION
Make the Firebase-distribution workflow build the exact commit that passed CI and inject a unique `versionCode`/`versionName` on every run, so each upload appears as a new release and installs correctly on testers’ devices.
