### PR TITLE
fix app crash caused by api returning duplicated media

### DIFF
--- a/data/remote_data_source/vod/src/main/java/com/sanaa/vod/media/actor/RemoteActorDataSourceImpl.kt
+++ b/data/remote_data_source/vod/src/main/java/com/sanaa/vod/media/actor/RemoteActorDataSourceImpl.kt
@@ -18,12 +18,12 @@ class RemoteActorDataSourceImpl(
     }
 
     override suspend fun getActorMovies(actorId: Int): List<ActorCastCreditDto> =
-        wrapApiCall { apiService.fetchActorMovies(actorId).cast }
+        wrapApiCall { apiService.fetchActorMovies(actorId).cast.distinctBy { it.id } }
 
     override suspend fun getActorTvShows(actorId: Int): List<ActorCastCreditDto> =
-        wrapApiCall { apiService.fetchActorTvShows(actorId).cast }
+        wrapApiCall { apiService.fetchActorTvShows(actorId).cast.distinctBy { it.id } }
 
     override suspend fun fetchTrendingPeople(page: Int): List<ActorDto>  =
-        wrapApiCall {  apiService.fetchTrendingPeople(page = page).results
+        wrapApiCall {  apiService.fetchTrendingPeople(page = page).results.distinctBy { it.id }
     }
 }

--- a/data/remote_data_source/vod/src/main/java/com/sanaa/vod/media/movie/RemoteMovieDataSourceImpl.kt
+++ b/data/remote_data_source/vod/src/main/java/com/sanaa/vod/media/movie/RemoteMovieDataSourceImpl.kt
@@ -21,20 +21,20 @@ class RemoteMovieDataSourceImpl(
     }
 
     override suspend fun fetchCast(id: Int): List<ActorDto> = wrapApiCall {
-        apiService.fetchCast(id).cast
+        apiService.fetchCast(id).cast.distinctBy { it.id }
     }
 
     override suspend fun fetchSimilarMoviesByMovieId(id: Int): List<MovieDto> = wrapApiCall {
-        apiService.fetchSimilarMoviesByMovieId(id).results
+        apiService.fetchSimilarMoviesByMovieId(id).results.distinctBy { it.id }
     }
 
     override suspend fun fetchReviewsByMovieId(id: Int): List<ReviewDto> = wrapApiCall {
-        apiService.fetchReviewsByMovieId(id).results
+        apiService.fetchReviewsByMovieId(id).results.distinctBy { it.id }
     }
 
 
     override suspend fun fetchMoviesByCategory(category: Int): List<MovieDto> = wrapApiCall {
-        apiService.fetchMoviesByCategory(category).results
+        apiService.fetchMoviesByCategory(category).results.distinctBy { it.id }
     }
 
     override suspend fun fetchMovieTrailerUrl(id: Int): List<VideoDto> = wrapApiCall {
@@ -48,14 +48,14 @@ class RemoteMovieDataSourceImpl(
     }
 
     override suspend fun fetchPopularMovies(page: Int): List<MovieDto> =
-        apiService.getPopularMovies(page).results
+        apiService.getPopularMovies(page).results.distinctBy { it.id }
 
     override suspend fun fetchTrendingMovies(page: Int, genreId: Int?): List<MovieDto> =
-        apiService.fetchTrendingMovies(page, genreId?.toString()).results
+        apiService.fetchTrendingMovies(page, genreId?.toString()).results.distinctBy { it.id }
 
     override suspend fun fetchTopRatedMovies(page: Int, genreId: Int?): List<MovieDto> =
-        apiService.fetchTopRatingMovies(page, genreId?.toString()).results
+        apiService.fetchTopRatingMovies(page, genreId?.toString()).results.distinctBy { it.id }
 
     override suspend fun fetchUpcomingMovies(page: Int, genreId: Int?): List<MovieDto> =
-        apiService.fetchUpcomingMovies(page, genreId?.toString()).results
+        apiService.fetchUpcomingMovies(page, genreId?.toString()).results.distinctBy { it.id }
 }

--- a/data/remote_data_source/vod/src/main/java/com/sanaa/vod/media/tvShow/RemoteTvShowDataSourceImpl.kt
+++ b/data/remote_data_source/vod/src/main/java/com/sanaa/vod/media/tvShow/RemoteTvShowDataSourceImpl.kt
@@ -33,15 +33,15 @@ class RemoteTvShowDataSourceImpl(
     }
 
     override suspend fun getTvShowsByGenre(genreId: Int): List<TvShowDto> = wrapApiCall {
-        apiService.fetchTvShowsByCategory(genreId).results
+        apiService.fetchTvShowsByCategory(genreId).results.distinctBy { it.id }
     }
 
     override suspend fun getReviewsByTvShowId(id: Int): List<ReviewDto> = wrapApiCall {
-        apiService.fetchTvShowsReviews(id).results
+        apiService.fetchTvShowsReviews(id).results.distinctBy { it.id }
     }
 
     override suspend fun getTvShowCast(id: Int): List<ActorDto> = wrapApiCall {
-        apiService.fetchTvShowsCast(id).cast
+        apiService.fetchTvShowsCast(id).cast.distinctBy { it.id }
     }
 
     override suspend fun getEpisodeDetails(
@@ -59,29 +59,36 @@ class RemoteTvShowDataSourceImpl(
         seriesId: Int, seasonNumber: Int, episodeNumber: Int
     ): List<ActorDto> = wrapApiCall {
         apiService.fetchEpisodeGuestsOfHonor(seriesId, seasonNumber, episodeNumber).guestStars
+            .distinctBy { it.id }
     }
 
     override suspend fun getTvShowGenres(): List<GenreDto> {
-        return apiService.fetchTvShowsGenres().genres
+        return apiService.fetchTvShowsGenres().genres.distinctBy { it.id }
     }
 
     override suspend fun fetchPopularTvShows(
         page: Int,
     ): List<TvShowDto> {
-        return apiService.getPopularTvShows(page).results
+        return apiService.getPopularTvShows(page).results.distinctBy { it.id }
     }
 
     override suspend fun fetchTopRatedTvShows(
         page: Int,
         genreId: Int?
     ): List<TvShowDto> {
-        return apiService.fetchTopRatingTvShows(page, genreId?.toString()).results
+        return apiService.fetchTopRatingTvShows(
+            page,
+            genreId?.toString()
+        ).results.distinctBy { it.id }
     }
 
     override suspend fun fetchTrendingTvShows(
         page: Int,
         genreId: Int?
     ): List<TvShowDto> {
-        return apiService.fetchTrendingTvShows(page, genreId?.toString()).results
+        return apiService.fetchTrendingTvShows(
+            page,
+            genreId?.toString()
+        ).results.distinctBy { it.id }
     }
 }

--- a/data/remote_data_source/vod/src/test/java/com/sanaa/vod/media/MovieDetailsRemoteDataSourceImplTest.kt
+++ b/data/remote_data_source/vod/src/test/java/com/sanaa/vod/media/MovieDetailsRemoteDataSourceImplTest.kt
@@ -119,18 +119,20 @@ class MovieDetailsRemoteDataSourceImplTest {
     )
     val dummyActors = listOf<ActorDto>(
         ActorDto(
-            name = "A",
             id = 1,
+            name = "A",
         ), ActorDto(
-            name = "A",
-            id = 1,
+            id = 2,
+            name = "B",
         )
     )
     val dummyReviews = listOf<ReviewDto>(
         ReviewDto(
+            id = "1",
             author = "A",
             content = "A",
         ), ReviewDto(
+            id = "2",
             author = "A",
             content = "A",
         )

--- a/data/repositories/vod/src/main/java/com/sanaa/vod/repository/ActorRepositoryImpl.kt
+++ b/data/repositories/vod/src/main/java/com/sanaa/vod/repository/ActorRepositoryImpl.kt
@@ -10,8 +10,8 @@ import entity.Movie
 import entity.TvSeries
 import exceptions.NoNetworkException
 import exceptions.RetrievingDataFailureException
-import timber.log.Timber
 import repository.ActorRepository
+import timber.log.Timber
 import java.net.UnknownHostException
 
 class ActorRepositoryImpl(
@@ -43,10 +43,6 @@ class ActorRepositoryImpl(
                 it.toMovie()
             }.take(20)
         }
-
-    override suspend fun getActorTopTvSeries(id: Int): List<TvSeries> {
-        return emptyList()
-    }
 
 
     override suspend fun getActorTopTvShows(id: Int): List<TvSeries> =

--- a/data/repositories/vod/src/test/java/com/sanaa/vod/repository/ActorRepositoryImplTest.kt
+++ b/data/repositories/vod/src/test/java/com/sanaa/vod/repository/ActorRepositoryImplTest.kt
@@ -197,13 +197,6 @@ class ActorRepositoryImplTest {
     }
 
     @Test
-    fun `getActorTopTvSeries returns empty list`() = runTest {
-        val result = repository.getActorTopTvSeries(1)
-
-        assertThat(result).isEmpty()
-    }
-
-    @Test
     fun `getTrendingActors returns empty list`() = runTest {
         val result = repository.getTrendingActors(1)
 

--- a/domain/vod/src/main/java/repository/ActorRepository.kt
+++ b/domain/vod/src/main/java/repository/ActorRepository.kt
@@ -9,7 +9,6 @@ interface ActorRepository {
     suspend fun getProfileImageUrls(id: Int, count: Int): List<String>
     suspend fun getGalleryImageUrls(id: Int): List<String>
     suspend fun getActorTopMovies(id: Int): List<Movie>
-    suspend fun getActorTopTvSeries(id: Int): List<TvSeries>
     suspend fun getTrendingActors(page: Int): List<Actor>
     suspend fun getActorTopTvShows(id: Int): List<TvSeries>
 }

--- a/feature/media_details/presentation/src/main/java/com/sanaa/presentation/screen/actor/screen/TopMoviesScreen.kt
+++ b/feature/media_details/presentation/src/main/java/com/sanaa/presentation/screen/actor/screen/TopMoviesScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -31,15 +31,15 @@ import com.sanaa.designsystem.design_system.component.top_bar.NovixTopBar
 import com.sanaa.designsystem.design_system.component.top_bar.TopBarClickableIcon
 import com.sanaa.designsystem.design_system.theme.NovixTheme
 import com.sanaa.designsystem.design_system.theme.Theme
-import com.sanaa.image_viewer.component.RemoteBlurredHaramImageViewer
 import com.sanaa.feature.mediadetails.presentation.R
-import com.sanaa.presentation.shared_component.RemoteImagePlaceholder
-import com.sanaa.presentation.shared_component.cards.MediaPosterCard
-import com.sanaa.presentation.shared_component.cards.SaveIconChip
+import com.sanaa.image_viewer.component.RemoteBlurredHaramImageViewer
 import com.sanaa.presentation.navigation.LocalNavControllerProvider
 import com.sanaa.presentation.navigation.MovieDetailsScreenRoute
 import com.sanaa.presentation.screen.actor.ActorScreenUiState
 import com.sanaa.presentation.screen.actor.ActorViewModel
+import com.sanaa.presentation.shared_component.RemoteImagePlaceholder
+import com.sanaa.presentation.shared_component.cards.MediaPosterCard
+import com.sanaa.presentation.shared_component.cards.SaveIconChip
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -112,10 +112,10 @@ private fun TopMoviesContent(
                                 12.dp
                             )
                         ) {
-                            items(
+                            itemsIndexed(
                                 state.topMovies,
-                                key = { item -> item.id }
-                            ) { movie ->
+                                key = { index, _ -> index }
+                            ) { _, movie ->
                                 MediaPosterCard(
                                     posterImage = {
                                         RemoteBlurredHaramImageViewer(

--- a/feature/media_details/presentation/src/main/java/com/sanaa/presentation/screen/actor/screen/TopSeriesScreen.kt
+++ b/feature/media_details/presentation/src/main/java/com/sanaa/presentation/screen/actor/screen/TopSeriesScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -32,15 +32,15 @@ import com.sanaa.designsystem.design_system.component.top_bar.NovixTopBar
 import com.sanaa.designsystem.design_system.component.top_bar.TopBarClickableIcon
 import com.sanaa.designsystem.design_system.theme.NovixTheme
 import com.sanaa.designsystem.design_system.theme.Theme
-import com.sanaa.image_viewer.component.RemoteBlurredHaramImageViewer
 import com.sanaa.feature.mediadetails.presentation.R
-import com.sanaa.presentation.shared_component.RemoteImagePlaceholder
-import com.sanaa.presentation.shared_component.cards.MediaPosterCard
-import com.sanaa.presentation.shared_component.cards.SaveIconChip
+import com.sanaa.image_viewer.component.RemoteBlurredHaramImageViewer
 import com.sanaa.presentation.navigation.LocalNavControllerProvider
 import com.sanaa.presentation.navigation.SeriesDetailsScreenRoute
 import com.sanaa.presentation.screen.actor.ActorScreenUiState
 import com.sanaa.presentation.screen.actor.ActorViewModel
+import com.sanaa.presentation.shared_component.RemoteImagePlaceholder
+import com.sanaa.presentation.shared_component.cards.MediaPosterCard
+import com.sanaa.presentation.shared_component.cards.SaveIconChip
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -118,10 +118,10 @@ private fun TopSeriesContent(
                                 12.dp
                             )
                         ) {
-                            items(
+                            itemsIndexed(
                                 state.topTvSeries,
-                                key = { item -> item.id }
-                            ) { series ->
+                                key = { index, _ -> index }
+                            ) { _, series ->
                                 MediaPosterCard(
                                     posterImage = {
                                         RemoteBlurredHaramImageViewer(

--- a/feature/media_details/presentation/src/main/java/com/sanaa/presentation/screen/genreMovies/GenreMoviesScreen.kt
+++ b/feature/media_details/presentation/src/main/java/com/sanaa/presentation/screen/genreMovies/GenreMoviesScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -34,13 +34,13 @@ import com.sanaa.designsystem.design_system.component.top_bar.TopBarClickableIco
 import com.sanaa.designsystem.design_system.theme.NovixTheme
 import com.sanaa.designsystem.design_system.theme.Theme
 import com.sanaa.feature.mediadetails.presentation.R
+import com.sanaa.image_viewer.component.RemoteBlurredHaramImageViewer
+import com.sanaa.presentation.navigation.LocalNavControllerProvider
+import com.sanaa.presentation.navigation.MovieDetailsScreenRoute
 import com.sanaa.presentation.shared_component.RemoteImagePlaceholder
 import com.sanaa.presentation.shared_component.RequestToLoginBottomSheet
 import com.sanaa.presentation.shared_component.cards.MediaPosterCard
 import com.sanaa.presentation.shared_component.cards.SaveIconChip
-import com.sanaa.image_viewer.component.RemoteBlurredHaramImageViewer
-import com.sanaa.presentation.navigation.LocalNavControllerProvider
-import com.sanaa.presentation.navigation.MovieDetailsScreenRoute
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -121,10 +121,10 @@ fun GenreMoviesScreenContent(
                             verticalArrangement = Arrangement.spacedBy(12.dp),
                             horizontalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
-                            items(
+                            itemsIndexed(
                                 state.movies,
-                                key = { item -> item.id }
-                            ) { movie ->
+                                key = { index, _ -> index }
+                            ) { _, movie ->
                                 MediaPosterCard(
                                     posterImage = {
                                         RemoteBlurredHaramImageViewer(


### PR DESCRIPTION
the crash was caused by api returning duplicated movies or tv shows

the media grid in the top tv shows screen items has unique key = media.id, which lead to crash when id was duplicated
I solved that by making sure the returned media from the DataSource are unique by id