### PR TITLE
Fix bottom-sheet dismiss freeze

### DIFF
--- a/feature/media_details/presentation/src/main/java/com/sanaa/presentation/screen/series/SeriesScreen.kt
+++ b/feature/media_details/presentation/src/main/java/com/sanaa/presentation/screen/series/SeriesScreen.kt
@@ -265,7 +265,7 @@ fun SeriesScreenContent(
             RateBottomSheet(
                 isRateSelected = state.hasUserSelectedRate,
                 imdbRating = state.imdbRating,
-                onDismiss = interactionListener::onDismissRateBottomSheet,
+                onDismiss = interactionListener::onDismissAnyBottomSheet,
                 isVisible = state.showRateBottomSheet,
                 onSubmitButtonClick = interactionListener::onSubmitRateBottomSheet,
                 onRatingChanged = interactionListener::onRatingChanged
@@ -273,7 +273,7 @@ fun SeriesScreenContent(
         }
         if (state.showLoginBottomSheet) {
             RequestToLoginBottomSheet(
-                onDismiss = interactionListener::onDismissRateBottomSheet,
+                onDismiss = interactionListener::onDismissAnyBottomSheet,
                 onLoginButtonClick = { interactionListener.onLoginButtonClick() },
                 isVisible = state.showLoginBottomSheet
             )

--- a/feature/media_details/presentation/src/main/java/com/sanaa/presentation/screen/series/SeriesScreenInteractionListener.kt
+++ b/feature/media_details/presentation/src/main/java/com/sanaa/presentation/screen/series/SeriesScreenInteractionListener.kt
@@ -11,6 +11,7 @@ interface SeriesScreenInteractionListener {
     fun onPlayTrailerClicked()
     fun onRateClicked()
     fun onDismissRateBottomSheet()
+    fun onDismissAnyBottomSheet()
     fun onSaveSeriesClicked()
     fun onGenreClicked(genre: GenreUiModel)
     fun onRetryLoadDetails()

--- a/feature/media_details/presentation/src/main/java/com/sanaa/presentation/screen/series/SeriesViewModel.kt
+++ b/feature/media_details/presentation/src/main/java/com/sanaa/presentation/screen/series/SeriesViewModel.kt
@@ -95,6 +95,15 @@ class SeriesViewModel @Inject constructor(
         updateState { it.copy(showRateBottomSheet = false) }
     }
 
+    override fun onDismissAnyBottomSheet() {
+        updateState {
+            it.copy(
+                showRateBottomSheet  = false,
+                showLoginBottomSheet = false
+            )
+        }
+    }
+
     override fun onLoginButtonClick() {
         updateState { it.copy(showLoginBottomSheet = false) }
         emitEffect(SeriesScreenEffects.NavigateToLogin)


### PR DESCRIPTION
**Fix:** Screen froze after canceling a bottom sheet.
**Cause:** One sheet-visibility flag stayed true, so the scrim kept intercepting touches.
**Change:** New `onDismissAnyBottomSheet()` clears both flags both sheets use it.
