### PR TITLE
refactor watching media history screen

### DIFF
--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/BaseViewModel.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/BaseViewModel.kt
@@ -38,39 +38,42 @@ abstract class BaseViewModel<T, E>(
         _state.update(updater)
     }
 
-    protected fun <T> tryToExecute(
-        callee: suspend () -> T,
-        onSuccess: (T) -> Unit = {},
-        onError: (exception: NovixAppException) -> Unit = {},
-        dispatcher: CoroutineDispatcher = defaultDispatcher,
-    ) {
-        val handler = createExceptionHandler(onError)
-
-        viewModelScope.launch(dispatcher + handler) {
-            val result = callee()
-            onSuccess(result)
-        }
-    }
-
     protected fun emitEffect(effect: E) {
         viewModelScope.launch {
             _effect.emit(effect)
         }
     }
 
+    protected fun <T> tryToExecute(
+        onStart: () -> Unit = {},
+        block: suspend () -> T,
+        onSuccess: (T) -> Unit = {},
+        onError: (exception: NovixAppException) -> Unit = {},
+        dispatcher: CoroutineDispatcher = defaultDispatcher,
+    ) {
+        onStart()
+        val handler = createExceptionHandler(onError)
+
+        viewModelScope.launch(dispatcher + handler) {
+            val result = block()
+            onSuccess(result)
+        }
+    }
+
     protected fun <T> tryToCollect(
-        callee: suspend () -> Flow<T>,
+        onStart: () -> Unit = {},
+        block: suspend () -> Flow<T>,
         onCollect: suspend (T) -> Unit,
         onError: (exception: NovixAppException) -> Unit = {},
         dispatcher: CoroutineDispatcher = defaultDispatcher,
     ) {
+        onStart()
         val handler = createExceptionHandler(onError)
 
         viewModelScope.launch(dispatcher + handler) {
-            callee().collectLatest { result ->
+            block().collectLatest { result ->
                 onCollect(result)
             }
-
         }
     }
 

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/app/NovixApp.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/app/NovixApp.kt
@@ -27,10 +27,10 @@ import com.sanaa.presentation.api.navigation.WatchingMediaHistoryScreenRoute
 import com.sanaa.presentation.providers.LocalSafeContentThreshold
 import com.sanaa.presentation.providers.LocalThemeProvider
 import com.sanaa.presentation.screen.mediaTabScreen.topRatingScreen.TopRatedMediaScreen
-import com.sanaa.presentation.screen.mediaTabScreen.watchingHistoryScreen.WatchingMediaHistoryScreen
 import com.sanaa.presentation.screen.trendingMediaScreen.trendingMoviesScreen.TrendingMoviesScreen
 import com.sanaa.presentation.screen.trendingMediaScreen.trendingTvShowScreen.TrendingTvShowsScreen
 import com.sanaa.presentation.screen.trendingPeopleScreen.TrendingPeopleScreen
+import com.sanaa.presentation.screen.watchingHistoryScreen.WatchingMediaHistoryScreen
 
 @Composable
 fun NovixApp(

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/bottomsheet/addEditBookmark/AddBookmarkListViewModel.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/bottomsheet/addEditBookmark/AddBookmarkListViewModel.kt
@@ -43,7 +43,7 @@ class AddBookmarkListViewModel @Inject constructor(
         updateState { copy(isLoading = true, errorMessage = null) }
         val currentTitle = state.value.listTitle.trim()
         tryToExecute(
-            callee = { manageSavedListsUseCase.createSavedList(currentTitle) },
+            block = { manageSavedListsUseCase.createSavedList(currentTitle) },
             onSuccess = onAddBookmarkListSuccess(mediaId),
             onError = ::onErrorAccrue
         )

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/bottomsheet/saveToListBottomsheet/SaveToListViewModel.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/bottomsheet/saveToListBottomsheet/SaveToListViewModel.kt
@@ -26,7 +26,7 @@ class SaveToListViewModel @Inject constructor(
 
     private fun observePlaylists() {
         tryToCollect(
-            callee = { listsStatusProvider.savedLists },
+            block = { listsStatusProvider.savedLists },
             onCollect = ::onCollectPlaylists,
         )
     }
@@ -51,7 +51,7 @@ class SaveToListViewModel @Inject constructor(
         updateState { copy(isLoading = true, errorMessage = null) }
 
         tryToExecute(
-            callee = addMovieToSavedList(selectedListId, mediaId),
+            block = addMovieToSavedList(selectedListId, mediaId),
             onSuccess = onAddMovieToSavedListSuccess(mediaId),
             onError = ::onErrorAccrue
         )

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/homeScreen/HomeScreenViewModel.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/homeScreen/HomeScreenViewModel.kt
@@ -62,7 +62,7 @@ class HomeScreenViewModel @Inject constructor(
 
     fun updateUserLoggingStatus() {
         tryToCollect(
-            callee = { checkIfUserIsLoggedInUseCase.isLoggedIn() },
+            block = { checkIfUserIsLoggedInUseCase.isLoggedIn() },
             onCollect = ::onCollectLoggedFlag,
             onError = ::onDataLoadError
         )
@@ -75,7 +75,7 @@ class HomeScreenViewModel @Inject constructor(
     private fun fetchPopularMediaData() {
         updateState { copy(isLoadingPopular = true) }
         tryToExecute(
-            callee = ::loadPopularMediaOperation,
+            block = ::loadPopularMediaOperation,
             onSuccess = ::onFetchPopularMediaSuccess,
             onError = ::onDataLoadError
         )
@@ -101,7 +101,7 @@ class HomeScreenViewModel @Inject constructor(
     private fun fetchTopRatedMediaData() {
         updateState { copy(isLoadingTopRated = true) }
         tryToExecute(
-            callee = ::loadTopRatedMediaOperation,
+            block = ::loadTopRatedMediaOperation,
             onSuccess = ::onFetchTopRatedMediaSuccess,
             onError = ::onDataLoadError,
         )
@@ -128,7 +128,7 @@ class HomeScreenViewModel @Inject constructor(
 
     private fun fetchWatchedMediaData() {
         tryToCollect(
-            callee = ::loadWatchedMediaHistory,
+            block = ::loadWatchedMediaHistory,
             onCollect = ::onFetchWatchedMediaSuccess,
             onError = ::onDataLoadError
         )
@@ -146,7 +146,7 @@ class HomeScreenViewModel @Inject constructor(
 
     private fun fetchMovieGenres() {
         tryToExecute(
-            callee = ::fetchMovieGenresOperation,
+            block = ::fetchMovieGenresOperation,
             onSuccess = ::onFetchMovieGenresSuccess,
             onError = ::onDataLoadError,
         )
@@ -165,7 +165,7 @@ class HomeScreenViewModel @Inject constructor(
 
     private fun fetchUpcomingMovies(genreId: Int? = null) {
         tryToCollect(
-            callee = {
+            block = {
                 loadUpcomingMovies(genreId)
                     .combine(savedListsStatusProvider.savedIds) { pagingData, savedIds ->
                         pagingData.map { it.withSaved(savedIds) }

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/mediaTabScreen/topRatingScreen/TopRatedMediaScreenViewModel.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/mediaTabScreen/topRatingScreen/TopRatedMediaScreenViewModel.kt
@@ -50,7 +50,7 @@ class TopRatedMediaScreenViewModel @Inject constructor(
 
     fun updateUserLoggingStatus() {
         tryToCollect(
-            callee = { checkIfUserIsLoggedInUseCase.isLoggedIn() },
+            block = { checkIfUserIsLoggedInUseCase.isLoggedIn() },
             onCollect = ::onCollectLoggedFlag,
         )
         onDismissBottomSheet()
@@ -62,7 +62,7 @@ class TopRatedMediaScreenViewModel @Inject constructor(
 
     private fun fetchMovies(genreId: Int? = null) {
         tryToExecute(
-            callee = {
+            block = {
                 loadTopRatedMovies(genreId = genreId)
                     .combine(savedListsStatusProvider.savedIds) { pagingData, savedIds ->
                         pagingData.map { mediaItem ->
@@ -83,7 +83,7 @@ class TopRatedMediaScreenViewModel @Inject constructor(
 
     private fun fetchTvShows(genreId: Int? = null) {
         tryToExecute(
-            callee = { loadTopRatedTvShows(genreId = genreId) },
+            block = { loadTopRatedTvShows(genreId = genreId) },
             onSuccess = ::onFetchTvShowsSuccess,
             onError = ::onDataLoadError
         )
@@ -97,7 +97,7 @@ class TopRatedMediaScreenViewModel @Inject constructor(
 
     private fun fetchMovieGenres() {
         tryToExecute(
-            callee = ::fetchMovieGenresOperation,
+            block = ::fetchMovieGenresOperation,
             onSuccess = ::onFetchMovieGenresSuccess,
             onError = ::onDataLoadError
         )
@@ -122,7 +122,7 @@ class TopRatedMediaScreenViewModel @Inject constructor(
 
     private fun fetchTvShowGenres() {
         tryToExecute(
-            callee = ::fetchTvShowGenresOperation,
+            block = ::fetchTvShowGenresOperation,
             onSuccess = ::onFetchTvShowGenresSuccess,
             onError = ::onDataLoadError
         )

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/mediaTabScreen/watchingHistoryScreen/WatchingMediaHistoryScreenEffect.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/mediaTabScreen/watchingHistoryScreen/WatchingMediaHistoryScreenEffect.kt
@@ -1,9 +1,0 @@
-package com.sanaa.presentation.screen.mediaTabScreen.watchingHistoryScreen
-
-import com.sanaa.presentation.state.MediaTypeUi
-
-sealed interface WatchingMediaHistoryScreenEffect {
-    object NavigateBack : WatchingMediaHistoryScreenEffect
-    data class NavigateToMediaDetails(val id: Int, val mediaTypeUi: MediaTypeUi) : WatchingMediaHistoryScreenEffect
-    data class ShowError(val message: String) : WatchingMediaHistoryScreenEffect
-}

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/trendingMediaScreen/trendingMoviesScreen/TrendingMoviesScreenViewModel.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/trendingMediaScreen/trendingMoviesScreen/TrendingMoviesScreenViewModel.kt
@@ -48,7 +48,7 @@ class TrendingMoviesScreenViewModel @Inject constructor(
 
     fun updateUserLoggingStatus() {
         tryToCollect(
-            callee = { checkIfUserIsLoggedInUseCase.isLoggedIn() },
+            block = { checkIfUserIsLoggedInUseCase.isLoggedIn() },
             onCollect = { isLogged ->
                 updateState {
                     copy(
@@ -61,7 +61,7 @@ class TrendingMoviesScreenViewModel @Inject constructor(
 
     private fun fetchGenres() {
         tryToExecute(
-            callee = ::loadGenresOperation,
+            block = ::loadGenresOperation,
             onSuccess = ::onLoadGenresSuccess,
             onError = ::onDataLoadError
         )
@@ -80,7 +80,7 @@ class TrendingMoviesScreenViewModel @Inject constructor(
 
     private fun loadMovies() {
         tryToCollect(
-            callee = ::loadMoviesOperation,
+            block = ::loadMoviesOperation,
             onCollect = ::onLoadMoviesSuccess,
             onError = ::onDataLoadError
         )

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/trendingMediaScreen/trendingTvShowScreen/TrendingTvShowsScreenViewModel.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/trendingMediaScreen/trendingTvShowScreen/TrendingTvShowsScreenViewModel.kt
@@ -41,7 +41,7 @@ class TrendingTvShowsScreenViewModel @Inject constructor(
 
     fun updateUserLoggingStatus() {
         tryToCollect(
-            callee = { checkIfUserIsLoggedInUseCase.isLoggedIn() },
+            block = { checkIfUserIsLoggedInUseCase.isLoggedIn() },
             onCollect = ::onCollectLoggedFlag,
         )
     }
@@ -52,7 +52,7 @@ class TrendingTvShowsScreenViewModel @Inject constructor(
 
     private fun fetchGenres() {
         tryToExecute(
-            callee = ::loadGenresOperation,
+            block = ::loadGenresOperation,
             onSuccess = ::onLoadGenresSuccess,
             onError = ::onDataLoadError
         )
@@ -71,7 +71,7 @@ class TrendingTvShowsScreenViewModel @Inject constructor(
 
     private fun loadTvShows() {
         tryToCollect(
-            callee = ::loadTvShowsOperation,
+            block = ::loadTvShowsOperation,
             onCollect = ::onLoadTvShowsSuccess,
             onError = ::onDataLoadError
         )

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/trendingPeopleScreen/TrendingPeopleViewModel.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/trendingPeopleScreen/TrendingPeopleViewModel.kt
@@ -34,7 +34,7 @@ class TrendingPeopleViewModel @Inject constructor(
 
     private fun loadActors() {
         tryToCollect(
-            callee = ::loadActorsOperation,
+            block = ::loadActorsOperation,
             onCollect = ::onLoadActorsSuccess,
             onError = ::onDataLoadError
         )

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/watchingHistoryScreen/WatchingMediaHistoryScreen.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/watchingHistoryScreen/WatchingMediaHistoryScreen.kt
@@ -1,4 +1,4 @@
-package com.sanaa.presentation.screen.mediaTabScreen.watchingHistoryScreen
+package com.sanaa.presentation.screen.watchingHistoryScreen
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
@@ -14,10 +14,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -36,18 +34,120 @@ import com.sanaa.presentation.components.MediaListSectionContent
 import com.sanaa.presentation.components.MediaTabs
 import com.sanaa.presentation.components.NovixAnimatedSnackBarHost
 import com.sanaa.presentation.components.RefreshButton
-import com.sanaa.presentation.components.SnackData
 import com.sanaa.presentation.navigation.HomeApiEntryPoint
 import com.sanaa.presentation.state.MediaTypeUi
 import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun WatchingMediaHistoryScreen(
-    modifier: Modifier = Modifier,
     viewModel: WatchingMediaHistoryScreenViewModel = hiltViewModel(),
 ) {
     val state = viewModel.state.collectAsStateWithLifecycle()
 
+    EffectHandler(viewModel.effect)
+
+    WatchingMediaHistoryScreenContent(
+        state = state.value,
+        interactionListener = viewModel,
+    )
+}
+
+@Composable
+private fun WatchingMediaHistoryScreenContent(
+    state: WatchingMediaHistoryScreenUiState,
+    interactionListener: WatchingMediaHistoryScreenInteractionListener,
+) {
+
+    NovixScaffold(
+        topBar = {
+            TopBar(
+                leftContent = {
+                    TopBarClickableIcon(
+                        icon = painterResource(id = R.drawable.icon_back),
+                        onClick = interactionListener::onBackClick
+                    )
+                },
+                screenTitle = stringResource(R.string.watching_history),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp)
+            )
+        },
+        snackBarHost = {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.TopCenter
+            ) {
+                NovixAnimatedSnackBarHost(
+                    data = state.snackBarData,
+                    onDismiss = interactionListener::onSnackBarDismiss
+                )
+            }
+        },
+        modifier = Modifier.systemBarsPadding(),
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+
+            MediaTabs(
+                onTabClick = interactionListener::onMediaTabSelection,
+                selectedTab = state.selectedMediaTypeUiState,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            AnimatedContent(
+                targetState = state.selectedMediaTypeUiState,
+                transitionSpec = {
+                    fadeIn(animationSpec = tween(150, delayMillis = 150))
+                        .togetherWith(fadeOut(animationSpec = tween(150)))
+                },
+                modifier = Modifier.fillMaxSize()
+            ) { selectedMediaType ->
+                when (selectedMediaType) {
+
+                    MediaTypeUi.MOVIE -> {
+                        MediaListSectionContent(
+                            genres = state.movieGenres,
+                            mediaList = state.movieList,
+                            selectedGenreId = state.movieSelectedGenreId,
+                            onGenreClick = interactionListener::onMovieGenreClick,
+                            onMediaClick = { media ->
+                                interactionListener.onMediaClick(media.id, media.mediaTypeUi)
+                            },
+                            onSaveIconClick = interactionListener::onSaveIconClick,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
+
+                    MediaTypeUi.TV_SHOW -> {
+                        MediaListSectionContent(
+                            genres = state.tvShowGenres,
+                            mediaList = state.tvShowList,
+                            selectedGenreId = state.tvShowSelectedGenreId,
+                            onGenreClick = interactionListener::onTvShowGenreClick,
+                            onMediaClick = { media ->
+                                interactionListener.onMediaClick(media.id, media.mediaTypeUi)
+                            },
+                            onSaveIconClick = interactionListener::onSaveIconClick,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
+                }
+                if (state.showRefreshButton) {
+                    RefreshButton(onRetryClick = interactionListener::onRetryClick)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EffectHandler(
+    effect: SharedFlow<WatchingMediaHistoryScreenEffect>,
+) {
     val navController = LocalAppNavController.current
     val appContext = LocalContext.current.applicationContext
 
@@ -57,17 +157,15 @@ fun WatchingMediaHistoryScreen(
             .detailsApi()
     }
 
-    var snack by remember { mutableStateOf<SnackData?>(null) }
-
     LaunchedEffect(Unit) {
-        viewModel.effect.collect { effect ->
+        effect.collectLatest { effect ->
             when (effect) {
                 is WatchingMediaHistoryScreenEffect.NavigateBack -> {
                     navController.popBackStack()
                 }
 
                 is WatchingMediaHistoryScreenEffect.NavigateToMediaDetails -> {
-                    when (effect.mediaTypeUi) {
+                    when (effect.mediaTypeUiState) {
                         MediaTypeUi.MOVIE -> {
                             detailsApi.launch(
                                 context = navController.context,
@@ -84,107 +182,6 @@ fun WatchingMediaHistoryScreen(
                             )
                         }
                     }
-                }
-
-                is WatchingMediaHistoryScreenEffect.ShowError -> {
-                    snack = SnackData(message = effect.message, isError = true)
-                }
-            }
-        }
-    }
-    Box(modifier = modifier.systemBarsPadding()) {
-
-        WatchingMediaHistoryScreenContent(
-            title = stringResource(R.string.watching_history),
-            state = state.value,
-            interactionListener = viewModel,
-            modifier = Modifier,
-        )
-
-        NovixAnimatedSnackBarHost(
-            data = snack,
-            onDismiss = { snack = null }
-        )
-    }
-}
-
-@Composable
-private fun WatchingMediaHistoryScreenContent(
-    title: String,
-    state: WatchingMediaHistoryScreenUiState,
-    interactionListener: WatchingMediaHistoryScreenInteractionListener,
-    modifier: Modifier = Modifier,
-) {
-    val tvShows = state.tvShowList
-    val movies = state.movieList
-
-    NovixScaffold(
-        topBar = {
-            TopBar(
-                leftContent = {
-                    TopBarClickableIcon(
-                        icon = painterResource(id = R.drawable.icon_back),
-                        onClick = interactionListener::onBackClick
-                    )
-                },
-                screenTitle = title,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 12.dp)
-            )
-        },
-        modifier = modifier,
-    ) {
-        Column(
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-
-            MediaTabs(
-                onTabClick = interactionListener::onMediaTabSelection,
-                selectedTab = state.selectedMediaTypeUi,
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            AnimatedContent(
-                targetState = state.selectedMediaTypeUi,
-                transitionSpec = {
-                    fadeIn(animationSpec = tween(150, delayMillis = 150))
-                        .togetherWith(fadeOut(animationSpec = tween(150)))
-                },
-                modifier = Modifier.fillMaxSize()
-            ) { selectedMediaType ->
-                when (selectedMediaType) {
-
-                    MediaTypeUi.MOVIE -> {
-                        MediaListSectionContent(
-                            genres = state.movieGenres,
-                            mediaList = movies,
-                            selectedGenreId = state.movieSelectedGenreId,
-                            onGenreClick = interactionListener::onMovieGenreClick,
-                            onMediaClick = { media ->
-                                interactionListener.onMediaClick(media.id, media.mediaTypeUi)
-                            },
-                            onSaveIconClick = interactionListener::onSaveIconClick,
-                            modifier = Modifier.fillMaxSize()
-                        )
-                    }
-
-                    MediaTypeUi.TV_SHOW -> {
-                        MediaListSectionContent(
-                            genres = state.tvShowGenres,
-                            mediaList = tvShows,
-                            selectedGenreId = state.tvShowSelectedGenreId,
-                            onGenreClick = interactionListener::onTvShowGenreClick,
-                            onMediaClick = { media ->
-                                interactionListener.onMediaClick(media.id, media.mediaTypeUi)
-                            },
-                            onSaveIconClick = interactionListener::onSaveIconClick,
-                            modifier = Modifier.fillMaxSize()
-                        )
-                    }
-                }
-                if (state.showRefreshButton) {
-                    RefreshButton(onRetryClick = interactionListener::onRetryClick)
                 }
             }
         }

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/watchingHistoryScreen/WatchingMediaHistoryScreenEffect.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/watchingHistoryScreen/WatchingMediaHistoryScreenEffect.kt
@@ -1,0 +1,9 @@
+package com.sanaa.presentation.screen.watchingHistoryScreen
+
+import com.sanaa.presentation.state.MediaTypeUi
+
+sealed interface WatchingMediaHistoryScreenEffect {
+    object NavigateBack : WatchingMediaHistoryScreenEffect
+    data class NavigateToMediaDetails(val id: Int, val mediaTypeUiState: MediaTypeUi) :
+        WatchingMediaHistoryScreenEffect
+}

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/watchingHistoryScreen/WatchingMediaHistoryScreenInteractionListener.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/watchingHistoryScreen/WatchingMediaHistoryScreenInteractionListener.kt
@@ -1,14 +1,15 @@
-package com.sanaa.presentation.screen.mediaTabScreen.watchingHistoryScreen
+package com.sanaa.presentation.screen.watchingHistoryScreen
 
 import com.sanaa.presentation.state.MediaItem
 import com.sanaa.presentation.state.MediaTypeUi
 
 interface WatchingMediaHistoryScreenInteractionListener {
-    fun onMediaTabSelection(mediaTypeUi: MediaTypeUi)
+    fun onMediaTabSelection(mediaTypeUiState: MediaTypeUi)
     fun onMovieGenreClick(id: Int?)
     fun onTvShowGenreClick(id: Int?)
-    fun onMediaClick(id: Int, mediaTypeUi: MediaTypeUi)
+    fun onMediaClick(id: Int, mediaTypeUiState: MediaTypeUi)
     fun onSaveIconClick(media: MediaItem)
     fun onBackClick()
     fun onRetryClick()
+    fun onSnackBarDismiss()
 }

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/watchingHistoryScreen/WatchingMediaHistoryScreenUiState.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/watchingHistoryScreen/WatchingMediaHistoryScreenUiState.kt
@@ -1,11 +1,12 @@
-package com.sanaa.presentation.screen.mediaTabScreen.watchingHistoryScreen
+package com.sanaa.presentation.screen.watchingHistoryScreen
 
+import com.sanaa.presentation.components.SnackData
 import com.sanaa.presentation.state.GenreUiState
 import com.sanaa.presentation.state.MediaItem
 import com.sanaa.presentation.state.MediaTypeUi
 
 data class WatchingMediaHistoryScreenUiState(
-    val selectedMediaTypeUi: MediaTypeUi = MediaTypeUi.MOVIE,
+    val selectedMediaTypeUiState: MediaTypeUi = MediaTypeUi.MOVIE,
     val movieList: List<MediaItem> = emptyList(),
     val tvShowList: List<MediaItem> = emptyList(),
     val movieGenres: List<GenreUiState> = emptyList(),
@@ -16,4 +17,5 @@ data class WatchingMediaHistoryScreenUiState(
     val showRefreshButton: Boolean = false,
     val isNoInternetConnection: Boolean = false,
     val showBottomSheet: Boolean = false,
+    val snackBarData: SnackData? = null
 )

--- a/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/watchingHistoryScreen/WatchingMediaHistoryScreenViewModel.kt
+++ b/feature/home/presentation/src/main/java/com/sanaa/presentation/screen/watchingHistoryScreen/WatchingMediaHistoryScreenViewModel.kt
@@ -1,11 +1,12 @@
-package com.sanaa.presentation.screen.mediaTabScreen.watchingHistoryScreen
+package com.sanaa.presentation.screen.watchingHistoryScreen
 
 import com.sanaa.presentation.BaseViewModel
+import com.sanaa.presentation.components.SnackData
+import com.sanaa.presentation.state.GenreUiState
 import com.sanaa.presentation.state.MediaItem
 import com.sanaa.presentation.state.MediaTypeUi
 import com.sanaa.presentation.state.mapper.toState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import entity.Genre
 import entity.MediaHistoryItem
 import exceptions.NoLoggedInUserException
 import exceptions.NoNetworkException
@@ -45,7 +46,7 @@ class WatchingMediaHistoryScreenViewModel @Inject constructor(
 
     private fun fetchMovies(genreId: Int? = null) {
         tryToCollect(
-            callee = { loadMediaHistory(mediaType = MediaType.MOVIE, genreId = genreId) },
+            block = { loadMediaHistory(mediaType = MediaType.MOVIE, genreId = genreId) },
             onCollect = ::onFetchMoviesSuccess,
             onError = ::onDataLoadError
         )
@@ -63,7 +64,7 @@ class WatchingMediaHistoryScreenViewModel @Inject constructor(
 
     private fun fetchTvShows(genreId: Int? = null) {
         tryToCollect(
-            callee = { loadMediaHistory(mediaType = MediaType.TV_SHOW, genreId = genreId) },
+            block = { loadMediaHistory(mediaType = MediaType.TV_SHOW, genreId = genreId) },
             onCollect = ::onFetchTvShowsSuccess,
             onError = ::onDataLoadError
         )
@@ -81,23 +82,17 @@ class WatchingMediaHistoryScreenViewModel @Inject constructor(
 
     private fun fetchMovieGenres() {
         tryToExecute(
-            callee = ::fetchMovieGenresOperation,
+            onStart = { updateState { copy(isLoading = true) } },
+            block = { manageMovieUseCase.getMovieGenres().map { it.toState() } },
             onSuccess = ::onFetchMovieGenresSuccess,
             onError = ::onDataLoadError
         )
     }
 
-    private suspend fun fetchMovieGenresOperation(): List<Genre> {
-        updateState {
-            copy(isLoading = true)
-        }
-        return manageMovieUseCase.getMovieGenres()
-    }
-
-    private fun onFetchMovieGenresSuccess(genres: List<Genre>) {
+    private fun onFetchMovieGenresSuccess(genres: List<GenreUiState>) {
         updateState {
             copy(
-                movieGenres = genres.map { it.toState() },
+                movieGenres = genres,
                 isLoading = false,
                 showRefreshButton = false
             )
@@ -106,31 +101,25 @@ class WatchingMediaHistoryScreenViewModel @Inject constructor(
 
     private fun fetchTvShowGenres() {
         tryToExecute(
-            callee = ::fetchTvShowGenresOperation,
+            onStart = { updateState { copy(isLoading = true) } },
+            block = { manageTvShowUseCase.getTvShowGenres().map { it.toState() } },
             onSuccess = ::onFetchTvShowGenresSuccess,
             onError = ::onDataLoadError
         )
     }
 
-    private suspend fun fetchTvShowGenresOperation(): List<Genre> {
-        updateState {
-            copy(isLoading = true)
-        }
-        return manageTvShowUseCase.getTvShowGenres()
-    }
-
-    private fun onFetchTvShowGenresSuccess(genres: List<Genre>) {
+    private fun onFetchTvShowGenresSuccess(genres: List<GenreUiState>) {
         updateState {
             copy(
-                tvShowGenres = genres.map { it.toState() },
+                tvShowGenres = genres,
                 isLoading = false,
                 showRefreshButton = false
             )
         }
     }
 
-    override fun onMediaTabSelection(mediaTypeUi: MediaTypeUi) {
-        updateState { copy(selectedMediaTypeUi = mediaTypeUi) }
+    override fun onMediaTabSelection(mediaTypeUiState: MediaTypeUi) {
+        updateState { copy(selectedMediaTypeUiState = mediaTypeUiState) }
     }
 
     override fun onMovieGenreClick(id: Int?) {
@@ -147,16 +136,12 @@ class WatchingMediaHistoryScreenViewModel @Inject constructor(
         fetchTvShows(id)
     }
 
-    override fun onMediaClick(id: Int, mediaTypeUi: MediaTypeUi) {
-        emitEffect(WatchingMediaHistoryScreenEffect.NavigateToMediaDetails(id, mediaTypeUi))
+    override fun onMediaClick(id: Int, mediaTypeUiState: MediaTypeUi) {
+        emitEffect(WatchingMediaHistoryScreenEffect.NavigateToMediaDetails(id, mediaTypeUiState))
     }
 
     override fun onSaveIconClick(media: MediaItem) {
-        updateState {
-            copy(
-                showBottomSheet = true
-            )
-        }
+        updateState { copy(showBottomSheet = true) }
     }
 
     override fun onBackClick() {
@@ -170,32 +155,56 @@ class WatchingMediaHistoryScreenViewModel @Inject constructor(
         fetchTvShowGenres()
     }
 
+    override fun onSnackBarDismiss() {
+        updateState { copy(snackBarData = null) }
+    }
+
     private suspend fun loadMediaHistory(
         mediaType: MediaType,
         genreId: Int?
     ): Flow<List<MediaHistoryItem>> {
         updateState { copy(isLoading = true) }
-      return try {
+        return try {
             return getLoggedInUserUseCase.getLoggedInUser().first().run {
-                 manageWatchedMediaHistoryUseCase.getMediaHistory(
+                manageWatchedMediaHistoryUseCase.getMediaHistory(
                     genreId = genreId,
                     mediaType = mediaType,
                     username = username
                 )
             }
 
-        } catch (_: NoLoggedInUserException){
+        } catch (_: NoLoggedInUserException) {
             flowOf(emptyList())
         }
     }
 
     private fun onDataLoadError(e: NovixAppException) {
-        if (e is NoNetworkException) {
-            updateState { copy(isNoInternetConnection = true, showRefreshButton = true) }
-            emitEffect(WatchingMediaHistoryScreenEffect.ShowError(message = stringProvider.noInternetConnectionError))
-        } else {
-            updateState { copy(isNoInternetConnection = false, showRefreshButton = true) }
-            emitEffect(WatchingMediaHistoryScreenEffect.ShowError(message = stringProvider.somethingWentWrongError))
+        when (e) {
+            is NoNetworkException -> {
+                updateState {
+                    copy(
+                        isNoInternetConnection = true,
+                        snackBarData =
+                            SnackData(
+                                message = stringProvider.noInternetConnectionError,
+                                isError = true
+                            )
+                    )
+                }
+            }
+
+            else -> {
+                updateState {
+                    copy(
+                        isNoInternetConnection = false,
+                        snackBarData =
+                            SnackData(
+                                message = stringProvider.somethingWentWrongError,
+                                isError = true
+                            )
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# What have been done
this pr is part of PR #597  but only for watching media history screens

1- separate trending movies from trending tv show screen
2- make all view models has smaller meaningful functions
3- rename misleading parameters
4- extract all snackbar messages into the string provider
5- move anything related to the design inside the screen content
6- add screen effect handler
7- modify the baseViewModel